### PR TITLE
Support Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
     "name": "karakus/laravel-cloudflare",
     "prefer-stable": true,
     "require": {
-        "illuminate/console": "5.6.*",
-        "illuminate/http": "5.6.*",
-        "illuminate/support": "5.6.*",
+        "illuminate/console": "^5.6",
+        "illuminate/http": "^5.6",
+        "illuminate/support": "^5.6",
         "ixudra/curl": "6.16.*"
     },
     "support": {


### PR DESCRIPTION
Right now this package does not supports Laravel 5.6 *or newer*, because of the dependency "5.6.*".
To support newer version, we can just add dependencies as "^5.6"